### PR TITLE
Event handler fix

### DIFF
--- a/mapinfo.txt
+++ b/mapinfo.txt
@@ -1,4 +1,4 @@
 gameinfo
 {
-	EventHandlers = "ZSWin_Handler"
+	AddEventHandlers = "ZSWin_Handler"
 }


### PR DESCRIPTION
EventHandlers mapinfo option DELETE already existed event list and create new one from defined after this command.
AddEventHandlers SUDDENLY add events to already existing list of all events.
What that mean is this mod would break all other mods loaded alongside with it.

How Gzdoom add events with EventHandlers and AddEventHandlers options
https://github.com/coelckers/gzdoom/blob/712d80006a2fa9152524c5cb442be7e31e98bbbb/src/gamedata/gi.cpp#L378
GAMEINFOKEY_STRINGARRAY extends here
https://github.com/coelckers/gzdoom/blob/712d80006a2fa9152524c5cb442be7e31e98bbbb/src/gamedata/gi.cpp#L131